### PR TITLE
`EsriASCIIRasterHeader::index_of` no longer requires mut ref

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -94,7 +94,7 @@ impl EsriASCIIRasterHeader {
         Some((x, y))
     }
     /// Get the row and column index of the cell that contains the given x and y, or nothing if it is out of bounds.
-    pub fn index_of(&mut self, x: f64, y: f64) -> Option<(usize, usize)> {
+    pub fn index_of(&self, x: f64, y: f64) -> Option<(usize, usize)> {
         if x < self.min_x() || x > self.max_x() || y < self.min_y() || y > self.max_y() {
             return None;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn test_index_of() {
         let file = std::fs::File::open("test_data/test.asc").unwrap();
-        let mut grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
+        let grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
         assert_eq!(
             grid.header
                 .index_of(grid.header.min_x(), grid.header.min_y())


### PR DESCRIPTION
This seems to be a mistake, which I only noticed while using the library.