### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.vscode/launch.json

--- a/readme.md
+++ b/readme.md
@@ -20,16 +20,15 @@ NODATA_value  -9999
 
 This library uses buffers to negate the need to load the entire ASCII grid into memory at once. The header will be loaded and will allow you to check the properties of the header. You can then either get specific values by index, coordinate or iterate over all points.
 
+This library will build a cache of position the start of each row without reading the data to memory as you use any 'get' method.
+Therefore, for large files the first few 'get' calls may be slow but will increase as the structure of the file is mapped out and cached.
+
 ## Usage:
 
 ```rust
 use esri_ascii_grid::ascii_file::EsriASCIIReader;
 let file = std::fs::File::open("test_data/test.asc").unwrap();
 let mut grid = EsriASCIIReader::from_file(file).unwrap();
-// Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-// This will build the index and cache the file positions of each line, it will take a while for large files
-// but will drastically increase the speed subsequent `get` calls.
-grid.build_index().unwrap();
 // Spot check a few values
 assert_eq!(
     grid.get_index(994, 7).unwrap(),

--- a/src/ascii_file.rs
+++ b/src/ascii_file.rs
@@ -36,10 +36,6 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
     /// use esri_ascii_grid::ascii_file::EsriASCIIReader;
     /// let file = std::fs::File::open("test_data/test.asc").unwrap();
     /// let mut grid = EsriASCIIReader::from_file(file).unwrap();
-    /// // Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-    /// // This will build the index and cache the file positions of each line, it will take a while for large files
-    /// // but will drastically increase the speed subsequent `get` calls.
-    /// grid.build_index().unwrap();
     /// // Spot check a few values
     /// assert_eq!(grid.get(390000.0, 344000.0).unwrap(), 141.2700042724609375);
     /// assert_eq!(grid.get(390003.0, 344003.0).unwrap(), 135.44000244140625);
@@ -65,27 +61,6 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
             },
         })
     }
-    /// Build an index of the file.
-    /// This will take a while for very large files, but will make subsequent calls to `get` or any such function much faster.
-    /// If you are going to be repeatedly calling and `get` on a big file it is recommended to call this function first.
-    ///
-    /// # Errors
-    /// Returns an error if there is some problem with the indexing, such as the file being too short.
-    pub fn build_index(&mut self) -> Result<(), crate::error::Error> {
-        // Clear any existing cache
-        self.line_start_cache = vec![None; self.header.num_rows()];
-        let num_rows = self.header.num_rows();
-        let reader = self.reader.by_ref();
-        reader.seek(SeekFrom::Start(self.data_start))?;
-        for row in (0..num_rows).rev() {
-            self.line_start_cache[row] = Some(reader.stream_position()?);
-            reader
-                .lines()
-                .next()
-                .ok_or_else(|| crate::error::Error::MismatchedRowCount(num_rows, row))??;
-        }
-        Ok(())
-    }
     /// Returns the value at the given row and column.
     /// 0, 0 is the bottom left corner. The row and column are zero indexed.
     /// # Examples
@@ -93,10 +68,6 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
     /// use esri_ascii_grid::ascii_file::EsriASCIIReader;
     /// let file = std::fs::File::open("test_data/test.asc").unwrap();
     /// let mut grid = EsriASCIIReader::from_file(file).unwrap();
-    /// // Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-    /// // This will build the index and cache the file positions of each line, it will take a while for large files
-    /// // but will drastically increase the speed subsequent `get` calls.
-    /// grid.build_index().unwrap();
     /// // Spot check a few values
     /// assert_eq!(grid.get_index(0, 0).unwrap(), 141.270_004_272_460_937_5);
     /// assert_eq!(grid.get_index(3, 3).unwrap(), 135.440_002_441_406_25);
@@ -145,10 +116,6 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
     /// use esri_ascii_grid::ascii_file::EsriASCIIReader;
     /// let file = std::fs::File::open("test_data/test.asc").unwrap();
     /// let mut grid = EsriASCIIReader::from_file(file).unwrap();
-    /// // Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-    /// // This will build the index and cache the file positions of each line, it will take a while for large files
-    /// // but will drastically increase the speed subsequent `get` calls.
-    /// grid.build_index().unwrap();
     /// // Spot check a few values
     /// assert_eq!(grid.get(390000.0, 344000.0).unwrap(), 141.2700042724609375);
     /// assert_eq!(grid.get(390003.0, 344003.0).unwrap(), 135.44000244140625);
@@ -173,11 +140,7 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
     /// ```rust
     /// use esri_ascii_grid::ascii_file::EsriASCIIReader;
     /// let file = std::fs::File::open("test_data/test.asc").unwrap();
-    /// let mut grid = EsriASCIIReader::from_file(file).unwrap();
-    /// // Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-    /// // This will build the index and cache the file positions of each line, it will take a while for large files
-    /// // but will drastically increase the speed subsequent `get` calls.
-    /// grid.build_index().unwrap();
+    /// let mut grid = EsriASCIIReader::from_file(file).unwrap();;
     /// // Spot check a few values
     /// assert_eq!(grid.get_interpolate(390000.0, 344000.0).unwrap(), 141.2700042724609375);
     /// assert_eq!(grid.get_interpolate(390003.0, 344003.0).unwrap(), 135.44000244140625);

--- a/src/ascii_file.rs
+++ b/src/ascii_file.rs
@@ -122,7 +122,9 @@ impl<R: Read + Seek> EsriASCIIReader<R> {
     ///
     /// If the coordinates are outside the bounds of the raster, nothing is returned.
     ///
-    /// If the coordinates are within the bounds of the raster, but not on a cell, the value of the nearest cell is returned
+    /// If the coordinates are within the bounds of the raster, but not on a cell, the behaviour depends on the `corner_type` of the raster.
+    /// If the `corner_type` is `Corner`, the value at the bottom left corner of the cell is returned.
+    /// If the `corner_type` is `Center`, the value at the center of the cell is returned.
     ///
     /// # Examples
     /// ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,13 +292,26 @@ mod tests {
     fn test_many_gets() {
         let file = std::fs::File::open("test_data/test.asc").unwrap();
         let mut grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
-        for x in 0..grid.header.ncols {
-            for y in 0..grid.header.nrows {
-                let x_pos = x as f64 * grid.header.cell_size() + grid.header.min_x();
-                let y_pos = y as f64 * grid.header.cell_size() + grid.header.min_y();
+        let header = grid.header;
+        for row in 0..grid.header.ncols {
+            for col in 0..grid.header.nrows {
+                let x_pos = row as f64 * grid.header.cell_size() + grid.header.min_x();
+                let y_pos = col as f64 * grid.header.cell_size() + grid.header.min_y();
                 let val = grid.get(x_pos, y_pos).unwrap();
-                let val2 = grid.get_index(y, x).unwrap();
+                let val2 = grid.get_index(col, row).unwrap();
                 assert_eq!(val, val2);
+                if row == 3 && col == 3 {
+                    let (x, y) = header.index_pos(col, row).unwrap();
+                    assert_eq!(x, 390_003.0);
+                    assert_eq!(y, 344_003.0);
+                    assert_eq!(val, 135.440_002_441_406_25);
+                }
+                if row == 0 && col == 0 {
+                    let (x, y) = header.index_pos(col, row).unwrap();
+                    assert_eq!(x, 390_000.0);
+                    assert_eq!(y, 344_000.0);
+                    assert_eq!(val, 141.270_004_272_460_937_5);
+                }
             }
         }
     }
@@ -307,14 +320,27 @@ mod tests {
     fn test_many_gets_indexed() {
         let file = std::fs::File::open("test_data/test.asc").unwrap();
         let mut grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
+        let header = grid.header;
         grid.build_index().unwrap();
-        for x in 0..grid.header.ncols {
-            for y in 0..grid.header.nrows {
-                let x_pos = x as f64 * grid.header.cell_size() + grid.header.min_x();
-                let y_pos = y as f64 * grid.header.cell_size() + grid.header.min_y();
+        for row in 0..grid.header.ncols {
+            for col in 0..grid.header.nrows {
+                let x_pos = row as f64 * grid.header.cell_size() + grid.header.min_x();
+                let y_pos = col as f64 * grid.header.cell_size() + grid.header.min_y();
                 let val = grid.get(x_pos, y_pos).unwrap();
-                let val2 = grid.get_index(y, x).unwrap();
+                let val2 = grid.get_index(col, row).unwrap();
                 assert_eq!(val, val2);
+                if row == 3 && col == 3 {
+                    let (x, y) = header.index_pos(col, row).unwrap();
+                    assert_eq!(x, 390_003.0);
+                    assert_eq!(y, 344_003.0);
+                    assert_eq!(val, 135.440_002_441_406_25);
+                }
+                if row == 0 && col == 0 {
+                    let (x, y) = header.index_pos(col, row).unwrap();
+                    assert_eq!(x, 390_000.0);
+                    assert_eq!(y, 344_000.0);
+                    assert_eq!(val, 141.270_004_272_460_937_5);
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,6 @@
 //! use esri_ascii_grid::ascii_file::EsriASCIIReader;
 //! let file = std::fs::File::open("test_data/test.asc").unwrap();
 //! let mut grid = EsriASCIIReader::from_file(file).unwrap();
-//! // Indexing the file is optional, but is recommended if you are going to be repeatedly calling any `get` function
-//! // This will build the index and cache the file positions of each line, it will take a while for large files
-//! // but will drastically increase the speed subsequent `get` calls.
-//! grid.build_index().unwrap();
 //! // Spot check a few values
 //! assert_eq!(
 //!     grid.get_index(994, 7).unwrap(),
@@ -293,35 +289,6 @@ mod tests {
         let file = std::fs::File::open("test_data/test.asc").unwrap();
         let mut grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
         let header = grid.header;
-        for row in 0..grid.header.ncols {
-            for col in 0..grid.header.nrows {
-                let x_pos = row as f64 * grid.header.cell_size() + grid.header.min_x();
-                let y_pos = col as f64 * grid.header.cell_size() + grid.header.min_y();
-                let val = grid.get(x_pos, y_pos).unwrap();
-                let val2 = grid.get_index(col, row).unwrap();
-                assert_eq!(val, val2);
-                if row == 3 && col == 3 {
-                    let (x, y) = header.index_pos(col, row).unwrap();
-                    assert_eq!(x, 390_003.0);
-                    assert_eq!(y, 344_003.0);
-                    assert_eq!(val, 135.440_002_441_406_25);
-                }
-                if row == 0 && col == 0 {
-                    let (x, y) = header.index_pos(col, row).unwrap();
-                    assert_eq!(x, 390_000.0);
-                    assert_eq!(y, 344_000.0);
-                    assert_eq!(val, 141.270_004_272_460_937_5);
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_many_gets_indexed() {
-        let file = std::fs::File::open("test_data/test.asc").unwrap();
-        let mut grid = crate::ascii_file::EsriASCIIReader::from_file(file).unwrap();
-        let header = grid.header;
-        grid.build_index().unwrap();
         for row in 0..grid.header.ncols {
             for col in 0..grid.header.nrows {
                 let x_pos = row as f64 * grid.header.cell_size() + grid.header.min_x();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,17 @@ mod tests {
             .unwrap();
         assert_eq!(val2, expected2);
 
+        // At max_x and max_y there are fewer cells to interpolate with, so the interpolated value will be the same as the value as the lower left cell
+        assert_eq!(
+            grid.get_interpolate(
+                grid.header.max_x() - grid.header.cell_size() / 2.,
+                grid.header.max_y() - grid.header.cell_size() / 2.
+            )
+            .unwrap(),
+            grid.get_index(grid.header.num_rows() - 1, grid.header.num_cols() - 1)
+                .unwrap()
+        );
+
         // Bounds check
         let min_x = grid.header.min_x();
         let min_y = grid.header.min_y();
@@ -306,5 +317,86 @@ mod tests {
                 assert_eq!(val, val2);
             }
         }
+    }
+    #[test]
+    fn test_corner_types() {
+        let xll = 0.; // From the test data files.
+        let yll = 0.;
+
+        let type_corner = std::fs::File::open("test_data/test_llcorner.asc").unwrap();
+        let type_center = std::fs::File::open("test_data/test_llcenter.asc").unwrap();
+        let grid_corner = crate::ascii_file::EsriASCIIReader::from_file(type_corner).unwrap();
+        let grid_center = crate::ascii_file::EsriASCIIReader::from_file(type_center).unwrap();
+
+        let header_center = grid_center.header;
+        let header_corner = grid_corner.header;
+
+        // Assert that everything is the same except for the corner type
+        assert_eq!(header_center.ncols, header_corner.ncols);
+        assert_eq!(header_center.nrows, header_corner.nrows);
+        assert_eq!(header_center.cellsize, header_corner.cellsize);
+        assert_eq!(header_center.nodata_value, header_corner.nodata_value);
+        // Collect both iterators and confirm that they are the same
+        let iter_center = grid_center.into_iter();
+        let iter_corner = grid_corner.into_iter();
+        for (cell_center, cell_corner) in iter_center.zip(iter_corner) {
+            let (row_center, col_center, value_center) = cell_center.unwrap();
+            let (row_corner, col_corner, value_corner) = cell_corner.unwrap();
+            assert_eq!(row_center, row_corner);
+            assert_eq!(col_center, col_corner);
+            assert_eq!(value_center, value_corner);
+        }
+        // Check the bounds. If the corner type is corner, the min_x and min_y will be the same as the xll and yll
+        // Therefore, the min_x and min_y will be half a cell size smaller than the yllcentre and xllcentre
+        assert_eq!(
+            header_center.min_x(),
+            header_corner.min_x() - header_center.cell_size() / 2.0
+        );
+        assert_eq!(
+            header_center.min_y(),
+            header_corner.min_y() - header_center.cell_size() / 2.0
+        );
+
+        assert_eq!(header_center.min_x(), xll - header_center.cell_size() / 2.0);
+        assert_eq!(header_center.min_y(), yll - header_center.cell_size() / 2.0);
+
+        // However, the range covered by the grid should be the same
+        let range_x = 200.;
+        let range_y = 300.;
+        assert_eq!(header_center.max_x() - header_center.min_x(), range_x);
+        assert_eq!(header_center.max_y() - header_center.min_y(), range_y);
+        assert_eq!(header_corner.max_x() - header_corner.min_x(), range_x);
+        assert_eq!(header_corner.max_y() - header_corner.min_y(), range_y);
+
+        let type_corner = std::fs::File::open("test_data/test_llcorner.asc").unwrap();
+        let type_center = std::fs::File::open("test_data/test_llcenter.asc").unwrap();
+        let mut grid_center = crate::ascii_file::EsriASCIIReader::from_file(type_center).unwrap();
+        let mut grid_corner = crate::ascii_file::EsriASCIIReader::from_file(type_corner).unwrap();
+        // We can still get the extremes ok
+        grid_center
+            .get(header_center.min_x(), header_center.min_y())
+            .unwrap();
+        grid_center
+            .get(header_center.max_x(), header_center.max_y())
+            .unwrap();
+        grid_center
+            .get(header_center.min_x(), header_center.max_y())
+            .unwrap();
+        grid_center
+            .get(header_center.max_x(), header_center.min_y())
+            .unwrap();
+
+        grid_corner
+            .get(header_corner.min_x(), header_corner.min_y())
+            .unwrap();
+        grid_corner
+            .get(header_corner.max_x(), header_corner.max_y())
+            .unwrap();
+        grid_corner
+            .get(header_corner.min_x(), header_corner.max_y())
+            .unwrap();
+        grid_corner
+            .get(header_corner.max_x(), header_corner.min_y())
+            .unwrap();
     }
 }

--- a/test_data/test_llcenter.asc
+++ b/test_data/test_llcenter.asc
@@ -1,0 +1,12 @@
+ncols         4
+nrows         6
+xllcenter     0.0
+yllcenter     0.0
+cellsize      50.0
+NODATA_value  -9999
+-9999 -9999 5 2
+-9999 20 100 36
+3 8 35 10
+32 42 50 6
+88 75 27 9
+13 5 1 -9999

--- a/test_data/test_llcorner.asc
+++ b/test_data/test_llcorner.asc
@@ -1,0 +1,12 @@
+ncols         4
+nrows         6
+xllcorner     0.0
+yllcorner     0.0
+cellsize      50.0
+NODATA_value  -9999
+-9999 -9999 5 2
+-9999 20 100 36
+3 8 35 10
+32 42 50 6
+88 75 27 9
+13 5 1 -9999


### PR DESCRIPTION
- Fix incorrect corner parsing
- Use vectors instead of hashmaps for file position caches
- Build file position caches as 'get' is used
- Above makes build_index obsolote
- Remove build_index