### PR TITLE
Add optional support for ordered-float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ debug = true
 
 [dependencies]
 num-traits = "0.2.19"
+ordered-float = { version = "4.2.2", optional = true }
 replace_with = "0.1.7"
 thiserror = "1.0.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+ordered-float = ["dep:ordered-float"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
     #[error("Expecting a float: {0}")]
     ParseFloat(#[from] ParseFloatError),
 
+    #[cfg(feature = "ordered-float")]
+    #[error("A parsed float value resulted in a NaN")]
+    FloatIsNan,
+
     #[error("Expecting {0} rows; got {1}")]
     MismatchedRowCount(usize, usize),
 
@@ -40,4 +44,15 @@ pub enum Error {
 
     #[error("The value {0} in {1} cannot be represented as type {2}")]
     TypeCast(String, String, &'static str),
+}
+
+#[cfg(feature = "ordered-float")]
+impl From<ordered_float::ParseNotNanError<ParseFloatError>> for Error {
+    fn from(err: ordered_float::ParseNotNanError<ParseFloatError>) -> Self {
+        use ordered_float::ParseNotNanError as E;
+        match err {
+            E::ParseFloatError(e) => Self::ParseFloat(e),
+            E::IsNaN => Self::FloatIsNan,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,4 +548,14 @@ mod tests {
         // Check that we can get all the values
         multiple_grids.compare_to(100., 150., 35.);
     }
+
+    #[cfg(feature = "ordered-float")]
+    #[test]
+    fn can_parse_into_notnan() {
+        use ordered_float::NotNan;
+
+        let file = File::open("test_data/test.asc").unwrap();
+        let grid = EsriASCIIReader::<_, NotNan<f64>, NotNan<f64>>::from_file(file).unwrap();
+        assert!(grid.into_iter().all(|cell| cell.is_ok()));
+    }
 }


### PR DESCRIPTION
The parse error of `ordered-float` has an additional variant that needs to be handled. This PR adds an optional feature to allow parsing into `NotNan<f64>`.