### PR TITLE
Derive `Debug`, `PartialEq`, and `Eq` where appropriate

### DIFF
--- a/src/ascii_file.rs
+++ b/src/ascii_file.rs
@@ -11,6 +11,7 @@ use crate::{
     header::{EsriASCIIRasterHeader, Numerical},
 };
 
+#[derive(Debug)]
 struct LineSeeker {
     line: usize,
     position: u64,
@@ -30,6 +31,7 @@ impl LineSeeker {
 /// * `R` - The type of the file. This should be a file that implements `Read` and `Seek`.
 /// * `T` - The type of the coordinates. Should be a number.
 /// * `U` - The type of the height values in the grid. Should be a number
+#[derive(Debug)]
 pub struct EsriASCIIReader<R, T: Numerical, U: Numerical> {
     pub header: EsriASCIIRasterHeader<T, U>,
     reader: BufReader<R>,
@@ -301,6 +303,7 @@ fn seek_to_line<R: Read + Seek>(
     Ok(())
 }
 
+#[derive(Debug)]
 enum LineReader<R> {
     Uninitialized {
         data_start: u64,
@@ -355,6 +358,7 @@ impl<R: Read + Seek> Iterator for LineReader<R> {
     }
 }
 
+#[derive(Debug)]
 pub struct EsriASCIIRasterIntoIterator<R, T: Numerical, U: Numerical> {
     pub header: EsriASCIIRasterHeader<T, U>,
     line_reader: LineReader<R>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -53,7 +53,7 @@ where
 /// * `R` - The type of the file. This should be a file that implements `Read` and `Seek`.
 /// * `T` - The type of the coordinates. Should be a number.
 /// * `U` - The type of the height values in the grid. Should be a number
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EsriASCIIRasterHeader<T, U>
 where
     T: Numerical,


### PR DESCRIPTION
Comparing header equality is something I found useful. While I'm at it, I thought I might as well derive `Debug` as well.